### PR TITLE
fix: parse spec using ref-parser bundle() to handle circular refs

### DIFF
--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -9,7 +9,7 @@ export async function configureExtensionsUserProvided(
   specFilePathOrObject: string | object,
   cliParamOptions: { [option: string]: any }
 ): Promise<void> {
-  const result = decycle(await new $RefParser().dereference(specFilePathOrObject));
+  const result = decycle(await new $RefParser().bundle(specFilePathOrObject));
 
   resetJSONSchemaGenerator();
 

--- a/packages/http/src/utils/operations.ts
+++ b/packages/http/src/utils/operations.ts
@@ -18,9 +18,7 @@ export async function getHttpOperationsFromSpec(specFilePathOrObject: string | o
       'User-Agent': `PrismMockServer/${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
     },
   };
-  const result = decycle(
-    await new $RefParser().dereference(specFilePathOrObject, { resolve: { http: httpResolverOpts } })
-  );
+  const result = decycle(await new $RefParser().bundle(specFilePathOrObject, { resolve: { http: httpResolverOpts } }));
 
   let operations: IHttpOperation[] = [];
   if (isOpenAPI2(result)) operations = transformOas2Operations(result);


### PR DESCRIPTION
See https://apitools.dev/json-schema-ref-parser/docs/#circular-refs