### PR TITLE
fix: add patch for node-abort-controller to use non-polyfilled AbortController and AbortSignal

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import './patch'
+import './patch';
 import * as yargs from 'yargs';
 import mockCommand from './commands/mock';
 import proxyCommand from './commands/proxy';

--- a/packages/cli/src/patch.ts
+++ b/packages/cli/src/patch.ts
@@ -1,2 +1,4 @@
+/* eslint-disable */
+
 // @ts-ignore
-Object.assign(require("node-abort-controller"), {AbortController, AbortSignal});
+Object.assign(require('node-abort-controller'), { AbortController, AbortSignal });


### PR DESCRIPTION
Prism mock was failing when passed a URL because stoplightio imports a polyfill of AbortController and AbortSignal, which causes issues on new node versions that actually implement those, and perform brand checks on them.