### PR TITLE
chore: add all tests to CI

### DIFF
--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -16,7 +16,7 @@ jobs:
           yarn install
       - name: Run linter
         run: |
-          yarn lint packages/cli
+          yarn lint
       - name: Run tests
         run: |
-          yarn test packages/cli
+          yarn test

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -26,7 +26,7 @@ async function instantiatePrism(operations: IHttpOperation[]) {
   });
 
   // be careful with selecting the port: it can't be the same in different suite because test suites run in parallel
-  const address = await server.listen(30000, '127.0.0.1');
+  const address = await server.listen(0, '127.0.0.1');
 
   return {
     close: server.close.bind(server),


### PR DESCRIPTION
We used to only lint and test the `cli` package. However, we're now relying on all the prism packages, so we should lint and test all of them. It's not like it takes too much longer anyway.