### PR TITLE
fix: bump version of @stoplight/json

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^6.0.0",
-    "@stoplight/json": "3.21.6",
+    "@stoplight/json": "3.21.7",
     "@stoplight/json-schema-merge-allof": "0.7.8",
     "@stoplight/json-schema-sampler": "0.3.0",
     "@stainless-api/prism-core": "^5.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,18 +1267,6 @@
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"
 
-"@stoplight/json@3.21.6":
-  version "3.21.6"
-  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.21.6.tgz#0053ece24d6b19f372b11591f249ede48514ed5b"
-  integrity sha512-KGisXfNigoYdWIj1jA4p3IAAIW5YFpU9BdoECdjyDLBbhWGGHzs77e0STSCBmXQ/K3ApxfED2R7mQ79ymjzlvQ==
-  dependencies:
-    "@stoplight/ordered-object-literal" "^1.0.3"
-    "@stoplight/path" "^1.3.2"
-    "@stoplight/types" "^13.6.0"
-    jsonc-parser "~2.2.1"
-    lodash "^4.17.21"
-    safe-stable-stringify "^1.1"
-
 "@stoplight/json@3.21.7", "@stoplight/json@^3.18.1":
   version "3.21.7"
   resolved "https://registry.npmjs.org/@stoplight/json/-/json-3.21.7.tgz"


### PR DESCRIPTION
3.21.6 has some kind of bug with dereferencing that was fixed in 3.21.7.
